### PR TITLE
bugfix: `ConcurrentModificationError` from `CentrifugeBlockEntity` during multiplayer

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeBlockEntity.java
@@ -77,6 +77,8 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 	LerpedFloat ingredientRotation;
 	VintageAdvancementBehaviour advancementBehaviour;
 
+	private final CompoundTag nbtForAnim = new CompoundTag();
+
 	public CentrifugeBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
 
@@ -151,7 +153,7 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 		if (!clientPacket)
 			return;
 
-		NBTHelper.iterateCompoundList(compound.getList("VisualizedItems", Tag.TAG_COMPOUND),
+		NBTHelper.iterateCompoundList(nbtForAnim.getList("VisualizedItems", Tag.TAG_COMPOUND),
 				c -> visualizedOutputItems.add(IntAttached.with(OUTPUT_ANIMATION_TIME, ItemStack.of(c))));
 	}
 
@@ -168,7 +170,7 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 		if (!clientPacket)
 			return;
 
-		compound.put("VisualizedItems", NBTHelper.writeCompoundList(visualizedOutputItems, ia -> ia.getValue()
+		nbtForAnim.put("VisualizedItems", NBTHelper.writeCompoundList(visualizedOutputItems, ia -> ia.getValue()
 				.serializeNBT()));
 		visualizedOutputItems.clear();
 	}
@@ -190,7 +192,7 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 	}
 
 	private List<Recipe<?>> getRecipes() {
-		List<Recipe<?>> list =  RecipeFinder.get(centrifugationRecipesKey, level, this::matchStaticFilters);
+		List<Recipe<?>> list = RecipeFinder.get(centrifugationRecipesKey, level, this::matchStaticFilters);
 
 		return list.stream()
 				.filter(this::matchCentrifugeRecipe)


### PR DESCRIPTION
when a second player joins the host, the host receives this and kicks the player:
```log
[235��2025 15:26:14.339] [Netty Server IO #4/ERROR] [net.minecraft.network.PacketEncoder/]: Error receiving packet 8
java.util.ConcurrentModificationException: null
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1597) ~[?:?]
	at java.util.HashMap$KeyIterator.next(HashMap.java:1620) ~[?:?]
	at net.minecraft.nbt.CompoundTag.m_6434_(CompoundTag.java:133) ~[client-1.20.1-20230612.114412-srg.jar%23855!/:?]
	at net.minecraft.nbt.NbtIo.m_128950_(NbtIo.java:139) ~[client-1.20.1-20230612.114412-srg.jar%23855!/:?]
	at net.minecraft.nbt.NbtIo.m_128941_(NbtIo.java:108) ~[client-1.20.1-20230612.114412-srg.jar%23855!/:?]
	at net.minecraft.network.FriendlyByteBuf.m_130079_(FriendlyByteBuf.java:588) ~[client-1.20.1-20230612.114412-srg.jar%23855!/:?]
	at net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket.m_5779_(ClientboundBlockEntityDataPacket.java:44) ~[client-1.20.1-20230612.114412-srg.jar%23855!/:?]
...
```
which comes from `CentrifugeBlockEntity`'s NBT IO logic, mixing server data & client animations