### PR TITLE
Adds a compatibility recipe for all the mods that add sulfur dust

### DIFF
--- a/src/main/resources/data/vintageimprovements/recipes/pressurizing/compat/sulfur_dioxide_from_dust.json
+++ b/src/main/resources/data/vintageimprovements/recipes/pressurizing/compat/sulfur_dioxide_from_dust.json
@@ -1,0 +1,26 @@
+{
+	"type":"vintageimprovements:pressurizing",
+	"conditions": [
+		{
+			"type": "forge:not",
+			"value": {
+				"type": "forge:tag_empty",
+				"tag": "forge:dusts/sulfur"
+			}
+		}
+	],
+	"secondaryFluidOutput": 0,
+	"heatRequirement": "heated",
+	"ingredients": [ 
+		{
+			"tag": "forge:dusts/sulfur"
+		}
+	],
+	"results": [
+		{
+			"fluid": "vintageimprovements:sulfur_dioxide",
+			"amount": 1000
+		}
+	],
+	"processingTime": 400
+}


### PR DESCRIPTION
There's at least a dozen mods that add sulfur dust - and now you can use it in Vintage Improvements sulfuric acid recipe chain.