### PR TITLE
Adds fluid tags to Sulfuric Acid recipes and intermediates

### DIFF
--- a/src/main/resources/data/forge/tags/fluids/sulfur_dioxide.json
+++ b/src/main/resources/data/forge/tags/fluids/sulfur_dioxide.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "vintageimprovements:sulfur_dioxide"
+  ]
+}

--- a/src/main/resources/data/forge/tags/fluids/sulfur_trioxide.json
+++ b/src/main/resources/data/forge/tags/fluids/sulfur_trioxide.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "vintageimprovements:sulfur_trioxide"
+  ]
+}

--- a/src/main/resources/data/vintageimprovements/recipes/pressurizing/copper_sulfate.json
+++ b/src/main/resources/data/vintageimprovements/recipes/pressurizing/copper_sulfate.json
@@ -2,7 +2,7 @@
 	"type":"vintageimprovements:pressurizing",
 	"ingredients": [ 
 		{
-			"fluid": "vintageimprovements:sulfuric_acid",
+			"fluidTag": "forge:sulfuric_acid",
 			"amount": 200
 		},
 		{

--- a/src/main/resources/data/vintageimprovements/recipes/pressurizing/sulfur_trioxide.json
+++ b/src/main/resources/data/vintageimprovements/recipes/pressurizing/sulfur_trioxide.json
@@ -4,7 +4,7 @@
 	"heatRequirement": "heated",
 	"ingredients": [ 
 		{
-			"fluid": "vintageimprovements:sulfur_dioxide",
+			"fluidTag": "forge:sulfur_dioxide",
 			"amount": 250
 		},
 		{

--- a/src/main/resources/data/vintageimprovements/recipes/pressurizing/sulfur_trioxide_alt.json
+++ b/src/main/resources/data/vintageimprovements/recipes/pressurizing/sulfur_trioxide_alt.json
@@ -4,7 +4,7 @@
 	"heatRequirement": "superheated",
 	"ingredients": [ 
 		{
-			"fluid": "vintageimprovements:sulfur_dioxide",
+			"fluidTag": "forge:sulfur_dioxide",
 			"amount": 250
 		},
 		{

--- a/src/main/resources/data/vintageimprovements/recipes/pressurizing/sulfuric_acid.json
+++ b/src/main/resources/data/vintageimprovements/recipes/pressurizing/sulfuric_acid.json
@@ -3,7 +3,7 @@
 	"secondaryFluidInput": 1,
 	"ingredients": [ 
 		{
-			"fluid": "vintageimprovements:sulfur_trioxide",
+			"fluidTag": "forge:sulfur_trioxide",
 			"amount": 1000
 		},
 		{


### PR DESCRIPTION
* Sulfur Dioxide and Sulfur Trioxide fluids now have their own Forge tags
* All recipes that use Sulfuric Acid, Sulfur Dioxide and Sulfur Trioxide now use Forge tags

This improves compatibility with other mods that add sulfuric acid production - Mekanism, GregTech, etc.