### PR TITLE
Fixed vacuum chamber wrench compatibility

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlock.java
@@ -104,7 +104,7 @@ public class VacuumChamberBlock extends KineticBlock implements IBE<VacuumChambe
 		var pos = context.getClickedPos();
 
 		var be = this.getBlockEntity(worldIn, pos);
-		if (be != null)
+		if (be != null && be.runningTicks == 0)
 		{
 			be.changeMode();
 			if (worldIn.isClientSide()) {

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlock.java
@@ -96,21 +96,22 @@ public class VacuumChamberBlock extends KineticBlock implements IBE<VacuumChambe
 	public void appendHoverText(ItemStack itemStack, @Nullable BlockGetter getter, List<Component> list, TooltipFlag flag) {
 		list.add(Component.translatable(VintageImprovements.MODID + ".item_description.machine_rpm_requirements").append(" " + SpeedLevel.MEDIUM.getSpeedValue()).withStyle(ChatFormatting.GOLD));
 	}
+	
+	@Override
+	public InteractionResult onWrenched(BlockState state, UseOnContext context)
+	{
+		var worldIn = context.getLevel();
+		var pos = context.getClickedPos();
 
-	public InteractionResult use(BlockState state, Level worldIn, BlockPos pos, Player player, InteractionHand handIn,
-								 BlockHitResult hit) {
-		ItemStack heldItem = player.getItemInHand(handIn);
-
-		return onBlockEntityUse(worldIn, pos, be -> {
-			if (!heldItem.isEmpty()) {
-				if (heldItem.getItem() == AllItems.WRENCH.asItem() && be.runningTicks == 0) {
-					be.mode = !be.mode;
-					if (worldIn.isClientSide())
-						AllSoundEvents.WRENCH_ROTATE.playAt(worldIn, pos, 3, 1,true);
-				}
+		var be = this.getBlockEntity(worldIn, pos);
+		if (be != null)
+		{
+			be.changeMode();
+			if (worldIn.isClientSide()) {
+				AllSoundEvents.WRENCH_ROTATE.playAt(worldIn, pos, 3, 1, true);
 			}
-
-			return InteractionResult.PASS;
-		});
+			return InteractionResult.SUCCESS;
+		}
+		return InteractionResult.PASS;
 	}
 }


### PR DESCRIPTION
Changes the vacuum chamber to use the `onWrenched` interface method, which handles other kinds of wrench items instead of just create's, as opposed to the original one which only works with create's.
It also kinda looked like the original was trying to do what `onWrenched` already does?