### PR TITLE
fixed various issues related to vacuum chamber and centrifuge

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeStructuralBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeStructuralBlockEntity.java
@@ -58,8 +58,8 @@ public class CentrifugeStructuralBlockEntity extends SmartBlockEntity {
             }
         }
 
-        sendData();
-        setChanged();
+        //sendData();
+        //setChanged();
     }
 
     @Override

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/PressurizingRecipe.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/PressurizingRecipe.java
@@ -17,6 +17,7 @@ import com.simibubi.create.foundation.fluid.FluidIngredient;
 import com.simibubi.create.foundation.recipe.DummyCraftingContainer;
 import net.createmod.catnip.data.Iterate;
 import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -107,11 +108,13 @@ public class PressurizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 		return () -> AssemblyPressurizing::new;
 	}
 
-	public static boolean match(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be) {
+	public static boolean match(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, int step) {
 		FilteringBehaviour filter = basin.getFilter();
 		if (filter == null)
 			return false;
 
+		// 在simibubi的设计中，配方无法得知过滤器的黑白名单模式，过滤器无法得知配方的完整产出
+		// 因此这段代码不是我不想改，而是我没招了
 		boolean filterTest = filter.test(recipe.getResultItem(basin.getLevel()
 				.registryAccess()));
 		if (recipe instanceof BasinRecipe) {
@@ -127,14 +130,14 @@ public class PressurizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 		if (!filterTest)
 			return false;
 
-		return apply(basin, recipe, be, true);
+		return apply(basin, recipe, be, true, step);
 	}
 
-	public static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be) {
-		return apply(basin, recipe, be, false);
+	public static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, int step) {
+		return apply(basin, recipe, be, false, step);
 	}
 
-	private static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, boolean test) {
+	private static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, boolean test, int step) {
 		boolean isBasinRecipe = recipe instanceof BasinRecipe;
 		IItemHandler availableItems = basin.getCapability(ForgeCapabilities.ITEM_HANDLER)
 				.orElse(null);
@@ -169,6 +172,9 @@ public class PressurizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 			int[] extractedFluidsFromTank = new int[availableFluids.getTanks()];
 			int[] extractedSecondaryFluidsFromTank = new int[availableSecondaryFluids.getTanks()];
 
+			// 记录是否匹配到正确的半成品原料
+			boolean incompleteItemFound = false;
+
 			Ingredients: for (int i = 0; i < ingredients.size(); i++) {
 				Ingredient ingredient = ingredients.get(i);
 
@@ -179,6 +185,27 @@ public class PressurizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 					ItemStack extracted = availableItems.extractItem(slot, 1, true);
 					if (!ingredient.test(extracted))
 						continue;
+					// 序列装配时，判断是否为对应半成品原料
+					if (step != 0) {
+						String sequenceId = getSequenceId(recipe);
+						if (extracted.hasTag() && extracted.getTag().contains("SequencedAssembly")) {
+							// 已经匹配到主原料时，拒绝任何带有序列装配标签的物品
+							if (incompleteItemFound) continue;
+
+							CompoundTag tag = extracted.getTag().getCompound("SequencedAssembly");
+							// 匹配正确的序列装配主原料
+							if (sequenceId.equals(tag.getString("id"))
+									&& step == tag.getInt("Step") + 1) {
+								incompleteItemFound = true;
+							} else {
+								// 拒绝其他任何有序列装配标签的物品
+								continue;
+							}
+						} else if (step == 1) {
+							// 起始步骤物品可以没有序列装配标签
+							incompleteItemFound = true;
+						}
+					}
 					if (!simulate)
 						availableItems.extractItem(slot, 1, false);
 					extractedItemsFromSlot[slot]++;
@@ -186,6 +213,11 @@ public class PressurizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 				}
 
 				// something wasn't found
+				return false;
+			}
+
+			//正在执行序列装配配方，但未找到可用半成品原料
+			if(step != 0 && !incompleteItemFound){
 				return false;
 			}
 
@@ -269,6 +301,9 @@ public class PressurizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 				}
 			}
 
+			// 这里使用的本体代码有吞流体的bug
+			// (工作盆产出流体A和B，而一个输出槽为空，另一输出槽被无关流体C占用时)
+			// 不是我不想改，而是我没招了
 			if (!basin.acceptOutputs(recipeOutputItems, recipeOutputFluids, simulate))
 				return false;
 
@@ -313,4 +348,17 @@ public class PressurizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 		return secondaryFluidInputs;
 	}
 
+	public static String getSequenceId(Recipe<?> recipe) {
+		// simibubi解析序列装配配方时，为每个步骤创建一个子配方，并在配方id末尾添加_step_i
+		// 但是配方自身没有方法确认是否属于序列装配，也不知道属于哪个序列装配的哪一步
+		// 方法返回序列装配配方的id，step后的数字代表单个循环内的步骤，不能匹配物品实际加工步骤
+		// 仅在能确定是序列装配的前提下调用这个方法！
+		if (recipe instanceof PressurizingRecipe pressurizingRecipe) {
+			String key = pressurizingRecipe.getId().toString();
+			int last = key.lastIndexOf("_step_");
+			if (last > -1) return key.substring(0, last);
+		}
+
+		return "";
+	}
 }

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
@@ -318,12 +318,12 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 				assemblyRecipe = SequencedAssemblyRecipe.getRecipes(level, item,
 								VintageRecipes.VACUUMIZING.getType(), VacuumizingRecipe.class)
 						.filter((it) -> {
-							String id = PressurizingRecipe.getSequenceId(it);
+							String id = VacuumizingRecipe.getSequenceId(it);
 							if (id.isEmpty()) return false;
 
 							if (!itemSequenceId.isEmpty() && !id.equals(itemSequenceId)) return false;
 
-							return PressurizingRecipe.match(basin.get(), it, this, itemSequenceStep);
+							return VacuumizingRecipe.match(basin.get(), it, this, itemSequenceStep);
 						}).findFirst();
 
 				if (assemblyRecipe.isPresent()) {

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
@@ -12,14 +12,11 @@ import com.simibubi.create.content.kinetics.base.IRotate;
 import com.simibubi.create.content.processing.basin.BasinBlockEntity;
 import com.simibubi.create.content.processing.basin.BasinOperatingBlockEntity;
 import com.simibubi.create.content.processing.basin.BasinRecipe;
-import com.simibubi.create.content.processing.burner.BlazeBurnerBlock;
 import com.simibubi.create.content.processing.recipe.ProcessingRecipe;
 import com.simibubi.create.content.processing.sequenced.SequencedAssemblyRecipe;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import com.simibubi.create.foundation.blockEntity.behaviour.fluid.SmartFluidTankBehaviour;
 import com.simibubi.create.foundation.fluid.CombinedTankWrapper;
-import com.simibubi.create.foundation.fluid.FluidIngredient;
-import com.simibubi.create.foundation.item.SmartInventory;
 
 import com.simibubi.create.foundation.utility.CreateLang;
 import net.createmod.catnip.data.Couple;
@@ -28,7 +25,6 @@ import net.createmod.catnip.math.VecHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -37,7 +33,6 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -52,6 +47,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.templates.FluidTank;
+import net.minecraftforge.items.IItemHandler;
 
 public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 
@@ -64,13 +60,18 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 	public SmartFluidTankBehaviour outputTank;
 	public SmartFluidTankBehaviour inputTank;
 	public LazyOptional<IFluidHandler> fluidCapability;
-	boolean contentsChanged;
 	boolean mode;
 	VintageAdvancementBehaviour advancementBehaviour;
+
+	// 配方自身无法肯定是否为序列装配配方的一部分，也不能知道在处理装配的第几步
+	// 在不修改本体代码的前提下，只能让机器来记忆是否在执行序列装配配方
+	// 默认值为0，表示非序列装配，因此从1开始定为序列装配的步骤数
+	private int sequencedAssemblyStep;
 
 	public VacuumChamberBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
 		mode = false;
+		sequencedAssemblyStep = 0;
 	}
 
 	public boolean changeMode() {
@@ -106,10 +107,11 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 	public void addBehaviours(List<BlockEntityBehaviour> behaviours) {
 		super.addBehaviours(behaviours);
 
+		// 检测到副流体内容变化，需要让工作盆重新检查配方
 		inputTank = new SmartFluidTankBehaviour(SmartFluidTankBehaviour.INPUT, this, 2, 1000, true)
-				.whenFluidUpdates(() -> contentsChanged = true);
+				.whenFluidUpdates(() -> basinChecker.scheduleUpdate());
 		outputTank = new SmartFluidTankBehaviour(SmartFluidTankBehaviour.OUTPUT, this, 2, 1000, true)
-				.whenFluidUpdates(() -> contentsChanged = true)
+				.whenFluidUpdates(() -> basinChecker.scheduleUpdate())
 				.forbidInsertion();
 		behaviours.add(inputTank);
 		behaviours.add(outputTank);
@@ -140,6 +142,8 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 		running = compound.getBoolean("Running");
 		runningTicks = compound.getInt("Ticks");
 		mode = compound.getBoolean("Mode");
+		// 不存在时，默认读取到0
+		sequencedAssemblyStep = compound.getInt("sequencedAssemblyStep");
 		super.read(compound, clientPacket);
 
 		if (clientPacket && hasLevel())
@@ -151,6 +155,7 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 		compound.putBoolean("Running", running);
 		compound.putInt("Ticks", runningTicks);
 		compound.putBoolean("Mode", mode);
+		compound.putInt("isSequencedAssembly", sequencedAssemblyStep);
 		super.write(compound, clientPacket);
 	}
 
@@ -220,10 +225,10 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 		BasinBlockEntity basin = optionalBasin.get();
 		boolean wasEmpty = basin.canContinueProcessing();
 		if (!mode)
-			if (!VacuumizingRecipe.apply(basin, currentRecipe, this))
+			if (!VacuumizingRecipe.apply(basin, currentRecipe, this, sequencedAssemblyStep))
 				return;
 		if (mode)
-			if (!PressurizingRecipe.apply(basin, currentRecipe, this))
+			if (!PressurizingRecipe.apply(basin, currentRecipe, this, sequencedAssemblyStep))
 				return;
 		getProcessedRecipeTrigger().ifPresent(this::award);
 		basin.inputTank.sendDataImmediately();
@@ -239,87 +244,97 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 
 	@Override
 	protected List<Recipe<?>> getMatchingRecipes() {
-		Optional<BasinBlockEntity> basin = getBasin();
-
-		if (basin.isEmpty()) return null;
-		if (mode) {
-			for (int i = 0; i < basin.get().getInputInventory().getSlots(); i++) {
-				Optional<PressurizingRecipe> assemblyRecipe = SequencedAssemblyRecipe.
-						getRecipe(level, basin.get().getInputInventory().getStackInSlot(i),
-								VintageRecipes.PRESSURIZING.getType(), PressurizingRecipe.class);
-				if (assemblyRecipe.isPresent() && basin.get().getFilter().test(assemblyRecipe.get()
-						.getResultItem(RegistryAccess.EMPTY))) {
-					if (!assemblyRecipe.get().getRequiredHeat().testBlazeBurner(BlazeBurnerBlock.getHeatLevelOf(level.getBlockState(getBlockPos().below(3)))))
-						return getRecipes();
-
-					for (Ingredient cur : assemblyRecipe.get().getIngredients()) {
-						boolean find = false;
-
-						for (ItemStack item : cur.getItems()) {
-							if (item.getCount() <= basin.get().getInputInventory().countItem(item.getItem())) {
-								find = true;
-								break;
-							}
-						}
-
-						if (!find) return getRecipes();
-					}
-
-					for (FluidIngredient cur : assemblyRecipe.get().getFluidIngredients()) {
-						if (cur.test(basin.get().inputTank.getPrimaryHandler().getFluid())) break;
-
-						return getRecipes();
-					}
-					return ImmutableList.of(assemblyRecipe.get());
-				}
-			}
-		}
-		else {
-			for (int i = 0; i < basin.get().getInputInventory().getSlots(); i++) {
-				Optional<VacuumizingRecipe> assemblyRecipe = SequencedAssemblyRecipe.
-						getRecipe(level, basin.get().getInputInventory().getStackInSlot(i),
-								VintageRecipes.VACUUMIZING.getType(), VacuumizingRecipe.class);
-				if (assemblyRecipe.isPresent() && basin.get().getFilter().test(assemblyRecipe.get()
-						.getResultItem(RegistryAccess.EMPTY))) {
-					if (!assemblyRecipe.get().getRequiredHeat().testBlazeBurner(BlazeBurnerBlock.getHeatLevelOf(level.getBlockState(getBlockPos().below(3)))))
-						return getRecipes();
-
-					for (Ingredient cur : assemblyRecipe.get().getIngredients()) {
-						boolean find = false;
-
-						for (ItemStack item : cur.getItems()) {
-							if (item.getCount() <= basin.get().getInputInventory().countItem(item.getItem())) {
-								find = true;
-								break;
-							}
-						}
-
-						if (!find) return getRecipes();
-					}
-
-					for (FluidIngredient cur : assemblyRecipe.get().getFluidIngredients()) {
-						if (cur.test(basin.get().inputTank.getPrimaryHandler().getFluid()))
-							break;
-
-						return getRecipes();
-					}
-					return ImmutableList.of(assemblyRecipe.get());
-				}
-			}
+		Optional<? extends Recipe<?>> assemblyRecipe = matchAssemblyRecipe();
+		if(assemblyRecipe.isPresent()){
+			return ImmutableList.of(assemblyRecipe.get());
 		}
 
-		return getRecipes();
-	}
+		//未匹配到序列配方
+		sequencedAssemblyStep = 0;
 
-	List<Recipe<?>> getRecipes() {
 		List<Recipe<?>> res = new ArrayList<>();
-
 		for (Recipe recipe : super.getMatchingRecipes()) {
 			if (mode && recipe instanceof PressurizingRecipe) res.add(recipe);
 			else if (!mode && recipe instanceof VacuumizingRecipe) res.add(recipe);
 		}
 
 		return res;
+	}
+
+	protected Optional<? extends Recipe<?>> matchAssemblyRecipe(){
+		// 获取工作盆
+		Optional<BasinBlockEntity> basin = getBasin();
+		if (basin.isEmpty()) {
+			return Optional.empty();
+		}
+
+		// 获取盆内物品
+		IItemHandler availableItems = basin.get().getCapability(ForgeCapabilities.ITEM_HANDLER).orElse(null);
+		if(availableItems == null){
+			return Optional.empty();
+		}
+
+		// 遍历物品判断能否序列装配
+		Optional<? extends Recipe<?>> assemblyRecipe;
+		for(int slot = 0; slot < availableItems.getSlots(); slot++){
+			ItemStack item = availableItems.getStackInSlot(slot);
+			String itemSequenceId;
+			int itemSequenceStep;
+
+			// 检查物品的序列装配标签
+			if (item.hasTag() && item.getTag().contains("SequencedAssembly")) {
+				CompoundTag tag = item.getTag().getCompound("SequencedAssembly");
+				itemSequenceId = tag.getString("id");
+				itemSequenceStep = tag.getInt("Step") + 1;
+			} else {
+				// 装配起始物品可以不带序列装配标签
+				itemSequenceId = "";
+				itemSequenceStep = 1;
+			}
+
+			if(mode){	// 加压模式
+				// getRecipe方法仅能匹配到相同主原料的一种序列装配配方，改用getRecipes
+				assemblyRecipe = SequencedAssemblyRecipe.getRecipes(level, item,
+								VintageRecipes.PRESSURIZING.getType(), PressurizingRecipe.class)
+						.filter((it) -> {
+							// 特别地，simibubi假定序列装配中间物品都是独一无二的
+							// 因此可能把正在装配的中间物品当作其他装配的起始物品
+							// 本体的代码暂且不做修改，临时性地在这里过滤
+							String id = PressurizingRecipe.getSequenceId(it);
+							if (id.isEmpty()) return false;
+							// 拒绝带序列装配标签且不匹配的物品
+							if (!itemSequenceId.isEmpty() && !id.equals(itemSequenceId)) return false;
+
+							// 然后才检查过滤、加热、盆内原料、机器副原料
+							return PressurizingRecipe.match(basin.get(), it, this, itemSequenceStep);
+						}).findFirst();
+
+				// 记录机器将执行的序列配方步骤
+				if (assemblyRecipe.isPresent()) {
+					sequencedAssemblyStep = itemSequenceStep;
+					return assemblyRecipe;
+				}
+			} else {	// 减压模式，同上
+				assemblyRecipe = SequencedAssemblyRecipe.getRecipes(level, item,
+								VintageRecipes.VACUUMIZING.getType(), VacuumizingRecipe.class)
+						.filter((it) -> {
+							String id = PressurizingRecipe.getSequenceId(it);
+							if (id.isEmpty()) return false;
+
+							if (!itemSequenceId.isEmpty() && !id.equals(itemSequenceId)) return false;
+
+							return PressurizingRecipe.match(basin.get(), it, this, itemSequenceStep);
+						}).findFirst();
+
+				if (assemblyRecipe.isPresent()) {
+					sequencedAssemblyStep = itemSequenceStep;
+					return assemblyRecipe;
+				}
+			}
+		}
+
+		//无匹配序列装配配方
+		return Optional.empty();
 	}
 
 	@Override
@@ -330,17 +345,10 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 		if (!basin.isPresent())
 			return false;
 
-		SmartInventory outputInventory = basin.get().getOutputInventory();
-		for (int i = 0; i < outputInventory.getSlots(); i++) {
-			if (outputInventory.getStackInSlot(i).hasTag() &&
-					outputInventory.getStackInSlot(i).getTag().get("SequencedAssembly") != null) {
-				return false;
-			}
-		}
 		if (recipe instanceof VacuumizingRecipe r)
-			return r.match(basin.get(), recipe, this);
+			return r.match(basin.get(), recipe, this, sequencedAssemblyStep);
 		if (recipe instanceof PressurizingRecipe r)
-			return r.match(basin.get(), recipe, this);
+			return r.match(basin.get(), recipe, this, sequencedAssemblyStep);
 
 		return BasinRecipe.match(basin.get(), recipe);
 	}

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumizingRecipe.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumizingRecipe.java
@@ -17,6 +17,7 @@ import com.simibubi.create.foundation.fluid.FluidIngredient;
 import com.simibubi.create.foundation.recipe.DummyCraftingContainer;
 import net.createmod.catnip.data.Iterate;
 import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -107,11 +108,13 @@ public class VacuumizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 		return () -> AssemblyVacuumizing::new;
 	}
 
-	public static boolean match(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be) {
+	public static boolean match(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, int step) {
 		FilteringBehaviour filter = basin.getFilter();
 		if (filter == null)
 			return false;
 
+		// 在simibubi的设计中，配方无法得知过滤器的黑白名单模式，过滤器无法得知配方的完整产出
+		// 因此这段代码不是我不想改，而是我没招了
 		boolean filterTest = filter.test(recipe.getResultItem(basin.getLevel()
 				.registryAccess()));
 		if (recipe instanceof BasinRecipe) {
@@ -127,14 +130,14 @@ public class VacuumizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 		if (!filterTest)
 			return false;
 
-		return apply(basin, recipe, be, true);
+		return apply(basin, recipe, be, true, step);
 	}
 
-	public static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be) {
-		return apply(basin, recipe, be, false);
+	public static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, int step) {
+		return apply(basin, recipe, be, false, step);
 	}
 
-	private static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, boolean test) {
+	private static boolean apply(BasinBlockEntity basin, Recipe<?> recipe, VacuumChamberBlockEntity be, boolean test, int step) {
 		boolean isBasinRecipe = recipe instanceof BasinRecipe;
 		IItemHandler availableItems = basin.getCapability(ForgeCapabilities.ITEM_HANDLER)
 				.orElse(null);
@@ -169,6 +172,9 @@ public class VacuumizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 			int[] extractedFluidsFromTank = new int[availableFluids.getTanks()];
 			int[] extractedSecondaryFluidsFromTank = new int[availableSecondaryFluids.getTanks()];
 
+			// 记录是否匹配到正确的半成品原料
+			boolean incompleteItemFound = false;
+
 			Ingredients: for (int i = 0; i < ingredients.size(); i++) {
 				Ingredient ingredient = ingredients.get(i);
 
@@ -179,6 +185,27 @@ public class VacuumizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 					ItemStack extracted = availableItems.extractItem(slot, 1, true);
 					if (!ingredient.test(extracted))
 						continue;
+					// 序列装配时，判断是否为对应半成品原料
+					if (step != 0) {
+						String sequenceId = getSequenceId(recipe);
+						if (extracted.hasTag() && extracted.getTag().contains("SequencedAssembly")) {
+							// 已经匹配到主原料时，拒绝任何带有序列装配标签的物品
+							if (incompleteItemFound) continue;
+
+							CompoundTag tag = extracted.getTag().getCompound("SequencedAssembly");
+							// 匹配正确的序列装配主原料
+							if (sequenceId.equals(tag.getString("id"))
+									&& step == tag.getInt("Step") + 1) {
+								incompleteItemFound = true;
+							} else {
+								// 拒绝其他任何有序列装配标签的物品
+								continue;
+							}
+						} else if (step == 1) {
+							// 起始步骤物品可以没有序列装配标签
+							incompleteItemFound = true;
+						}
+					}
 					if (!simulate)
 						availableItems.extractItem(slot, 1, false);
 					extractedItemsFromSlot[slot]++;
@@ -186,6 +213,11 @@ public class VacuumizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 				}
 
 				// something wasn't found
+				return false;
+			}
+
+			// 正在执行序列装配配方，但未找到可用半成品原料
+			if (step != 0 && !incompleteItemFound) {
 				return false;
 			}
 
@@ -268,6 +300,9 @@ public class VacuumizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 				}
 			}
 
+			// 这里使用的本体代码有吞流体的bug
+			// (工作盆产出流体A和B，而一个输出槽为空，另一输出槽被无关流体C占用时)
+			// 不是我不想改，而是我没招了
 			if (!basin.acceptOutputs(recipeOutputItems, recipeOutputFluids, simulate))
 				return false;
 
@@ -312,4 +347,18 @@ public class VacuumizingRecipe extends BasinRecipe implements IAssemblyRecipe {
 		return secondaryFluidInputs;
 	}
 
+
+	public static String getSequenceId(Recipe<?> recipe) {
+		// simibubi解析序列装配配方时，为每个步骤创建一个子配方，并在配方id末尾添加_step_i
+		// 但是配方自身没有方法确认是否属于序列装配，也不知道属于哪个序列装配的哪一步
+		// 方法返回序列装配配方的id，step后的数字代表单个循环内的步骤，不能匹配物品实际加工步骤
+		// 仅在能确定是序列装配的前提下调用这个方法！
+		if (recipe instanceof VacuumizingRecipe vacuumizingRecipe) {
+			String key = vacuumizingRecipe.getId().toString();
+			int last = key.lastIndexOf("_step_");
+			if (last > -1) return key.substring(0, last);
+		}
+
+		return "";
+	}
 }


### PR DESCRIPTION
1.修复了离心机结构方块连接到红石比较器时的异常卡顿
2.修复了压缩机内部流体变化时不及时检查配方的bug
3.修复了单种主原料衍生出多种序列装配配方时，压缩机仅能匹配其中一种的bug
4.修复了从机械动力本体继承的序列装配串配方bug

1.Fixed severe lag issues when the centrifuge structural blocks are connected to a redstone comparator.
2.Fixed a bug where the vacuum chamber did not match recipes in time when its internal fluid changed.
3.Fixed an issue where the vacuum chamber could only match one recipe when multiple sequenced assembly recipes shared the same main ingredient.
4.Fixed an issue where incomplete item in a sequenced assembly recipe could be incorrectly treated as valid inputs for another assembly recipe.

ps.体验上最明显和有用的修改是前两点，只涉及了四行代码内容，pr中大量篇幅用来追求彻底修复压缩机冷门序列装配的bug，但是也给本就繁重的配方匹配任务雪上加霜，并不太算好的修复，而且受限于西米布比原版工作盆，一些问题依旧不能修复