### PR TITLE
Fix Vacuum Chamber Bug

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
@@ -34,6 +34,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -252,13 +253,35 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 		//未匹配到序列配方
 		sequencedAssemblyStep = 0;
 
-		List<Recipe<?>> res = new ArrayList<>();
-		for (Recipe recipe : super.getMatchingRecipes()) {
-			if (mode && recipe instanceof PressurizingRecipe) res.add(recipe);
-			else if (!mode && recipe instanceof VacuumizingRecipe) res.add(recipe);
-		}
+        List<Recipe<?>> res = new ArrayList<>();
 
-		return res;
+        Optional<BasinBlockEntity> basin = getBasin();
+        if (basin.isEmpty()) return res;
+
+        RecipeType<?> type = mode ?
+                VintageRecipes.PRESSURIZING.getType() :
+                VintageRecipes.VACUUMIZING.getType();
+
+        List<? extends Recipe<?>> allRecipes = null;
+        if (level != null) {
+            allRecipes = level.getRecipeManager().getAllRecipesFor((RecipeType) type);
+        }
+
+        if (allRecipes != null) {
+            for (Recipe<?> recipe : allRecipes) {
+                if (mode && recipe instanceof PressurizingRecipe pr) {
+                    if (pr.match(basin.get(), recipe, this, sequencedAssemblyStep)) {
+                        res.add(recipe);
+                    }
+                } else if (!mode && recipe instanceof VacuumizingRecipe vr) {
+                    if (vr.match(basin.get(), recipe, this, sequencedAssemblyStep)) {
+                        res.add(recipe);
+                    }
+                }
+            }
+        }
+
+        return res;
 	}
 
 	protected Optional<? extends Recipe<?>> matchAssemblyRecipe(){


### PR DESCRIPTION
尝试修复了压缩机必须检测到工作盆里也有对应流体才能工作的 Bug 。
现状：当前的版本，如果写一个压缩机配方，其中需求从压缩机处输入流体（而不是从工作盆中），那么按配方正常放置原料后，压缩机不会工作，必须在工作盆中放入相同的流体才能正常工作（但工作时，这些流体不会消耗，只是用于配方的启动）。
逻辑：原代码中查找配方时调用了工作盆的父类 super.getMatchingRecipes，而这个父类只会检测工作盆内的内容，而无从获取压缩机中的流体；它会认为必须所有输入都在工作盆里，才让配方放行。
本修复将这个逻辑替换为了手动匹配，已在多模组的服务器环境（真理之路官服）上使用 hotai 测试，未出现明显 Bug 或性能瓶颈。但这是本人第一次正经 PR ，希望作者能帮忙审查一下，然后再 merge。