### PR TITLE
Fix crash when placing rotated Centrifuge schematics in Creative mode

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeStructuralBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeStructuralBlock.java
@@ -308,10 +308,15 @@ public class CentrifugeStructuralBlock extends DirectionalBlock implements IBE<C
 			return;
 
 		CentrifugeBlockEntity centrifuge = null;
-		for (BlockPos pos : Iterate.hereAndBelow(entityIn.blockPosition()))
-			if (worldIn.getBlockState(pos).is(VintageBlocks.CENTRIFUGE_STRUCTURAL.get()))
-				if (centrifuge == null)
+		for (BlockPos pos : Iterate.hereAndBelow(entityIn.blockPosition())) {
+			if (worldIn.getBlockState(pos).is(VintageBlocks.CENTRIFUGE_STRUCTURAL.get())) {
+				// 获取结构主方块前检查，避免无限递归
+				if (stillValid(worldIn, pos, worldIn.getBlockState(pos), false)) {
 					centrifuge = (CentrifugeBlockEntity) worldIn.getBlockEntity(getMaster(worldIn, pos, worldIn.getBlockState(pos)));
+					break;
+				}
+			}
+		}
 		if (centrifuge == null)
 			return;
 

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeStructuralBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeStructuralBlockEntity.java
@@ -53,6 +53,11 @@ public class CentrifugeStructuralBlockEntity extends SmartBlockEntity {
         super.tick();
 
         if (cbe == null) {
+            // 获取结构主方块前检查，避免无限递归
+            if (!(getBlockState().getBlock() instanceof CentrifugeStructuralBlock structuralBlock))
+                return;
+            if (!structuralBlock.stillValid(getLevel(), getBlockPos(), getBlockState(), false))
+                return;
             if (level.getBlockEntity(CentrifugeStructuralBlock.getMaster(level, getBlockPos(), getBlockState())) instanceof CentrifugeBlockEntity be) {
                 cbe = be;
             }


### PR DESCRIPTION
**修复创造模式中直接打印旋转后的离心机蓝图导致无限递归崩服的问题**
**Fix infinite recursion crash when directly placing rotated Centrifuge schematics in Creative mode**

**原因**

- bug1:

机械动力打印旋转后蓝图时，在一些情况下会错误地跳过对朝向旋转/镜像的处理
When printing rotated schematics, Create may incorrectly skip facing/axis processing in certain cases.

- bug2:

离心机为原作者仿照原版机械动力大水车设计，但原作者在结构方块获取主方块时漏了检查有效性的步骤，容易陷入无限递归
The Centrifuge is implemented by the original author based on Create’s Water Wheel design. However, when retrieving the main block from structural blocks, the validity check was omitted, which can easily lead to infinite recursion.

- feat1:

创造模式直接放置蓝图会字面意义地遍历放置每一个方块，包括旋转时会出错的结构方块，而不像蓝图炮打印那样只放置离心机主方块
Directly placing schematics in Creative mode literally iterates and places every block, including structural blocks that break under rotation. This differs from cannon printing, which only places the Centrifuge’s main block.