### PR TITLE
Fix centrifuge not updating analog signal

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeBlockEntity.java
@@ -35,6 +35,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
@@ -83,8 +84,10 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 	public CentrifugeBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
 
-		inputInv = new SmartInventory(9, this);
-		outputInv = new SmartInventory(9, this);
+		inputInv = new SmartInventory(9, this)
+				.whenContentsChanged(slot -> contentsChanged = true);
+		outputInv = new SmartInventory(9, this)
+				.whenContentsChanged(slot -> contentsChanged = true);
 		capability = LazyOptional.of(() -> new CentrifugeInventoryHandler(inputInv, outputInv));
 		basins = 0;
 		visualizedOutputItems = Collections.synchronizedList(new ArrayList<>());
@@ -248,6 +251,21 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 
 		if (getBasins() < 4)
 			return;
+
+		// notifyUpdate if needed
+		if (redstoneApp && contentsChanged) {
+			BlockPos center = getBlockPos();
+			for (int dx = -1; dx <= 1; dx++) {
+				for (int dz = -1; dz <= 1; dz++) {
+					if (dx == 0 && dz == 0) continue;
+					BlockEntity be = level.getBlockEntity(center.offset(dx, 0, dz));
+					if (be instanceof CentrifugeStructuralBlockEntity cbe) {
+						cbe.notifyUpdate();
+					}
+				}
+			}
+			contentsChanged = false;
+		}
 
 		if (timer > 0) {
 			if (getSpeed() == 0) {


### PR DESCRIPTION
### 修复比较器无法及时发现离心机状态变化的问题
### Fix centrifuge not updating analog signal

先前的pr中我移除了离心机每gt产生更新的代码，这会带来约 100 ~ 200 uspt 的不必要卡顿。但不知为何我竟然忘了比较器需要这个更新来改变输出信号。
The centrifuge no longer updated its analog output after the per-tick update logic was removed for performance reasons.
While the removal eliminated about 100 ~ 200 µspt of unnecessary overhead in most cases, it also unintentionally removed the update propagation required when the working state changes.

现在离心机会检查内容变化来决定是否产生更新，测试表明在修复了 bug 的同时也几乎没有性能损耗。
The centrifuge now checks whether its analog signal value should change and only notify update when necessary, restoring correct behavior without reintroducing the original performance cost.