### PR TITLE
Make grinding recipe IDs unique

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/compat/jei/category/GrinderSandpaperPolishingCategory.java
+++ b/src/main/java/com/negodya1/vintageimprovements/compat/jei/category/GrinderSandpaperPolishingCategory.java
@@ -19,6 +19,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 
 import java.util.List;
 
@@ -51,6 +52,16 @@ public class GrinderSandpaperPolishingCategory extends CreateRecipeCategory<Sand
 			i++;
 		}
 	}
+
+    @Override
+    public ResourceLocation getRegistryName(SandPaperPolishingRecipe recipe) {
+        ResourceLocation id = super.getRegistryName(recipe);
+        if (id != null) {
+            return new ResourceLocation(id.getNamespace(),
+                    "grinder_" + id.getPath());
+        }
+        return id;
+    }
 
 	@Override
 	public void draw(SandPaperPolishingRecipe recipe, IRecipeSlotsView iRecipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY) {


### PR DESCRIPTION
When Vintage Improvements adds all polishing recipes to the grinder recipes category, it uses the same recipe IDs. This is fine for JEI, where recipe IDs are scoped to their category.

However, for EMI, recipe IDs are checked globally. So when JEI recipes are imported into EMI via JEMI or TMRV everything does still work, but EMI will record several hundred errors about duplicate IDs.
<img width="1315" height="199" alt="image" src="https://github.com/user-attachments/assets/c51ee591-e64f-411d-805d-254f9be5f295" />

This PR fixes this by renaming the polishing recipes that get added from namespace:polishing/ to namespace:grinder_polishing/