### PR TITLE
Fix laser not updating recipe cache correctly

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/laser/LaserBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/laser/LaserBlockEntity.java
@@ -166,7 +166,7 @@ public class LaserBlockEntity extends ElectricKineticBlockEntity implements IHav
 	private boolean laserRecipe(ItemStack stack, TransportedItemStack transported, TransportedItemStackHandlerBehaviour handler) {
 		if(this.getLevel() == null) return false;
 		if (Mth.abs(getSpeed()) == 0) return false;
-		if(!inputInv.getStackInSlot(0).is(stack.getItem())) {
+		if(!inputInv.getStackInSlot(0).equals(stack, true)) {
 			inputInv.setStackInSlot(0, stack);
 			recipeCache = find(new RecipeWrapper(inputInv), this.getLevel());
 			chargeAccumulator = 0;


### PR DESCRIPTION
激光不会正确更新配方缓存，它只会在物品变化时重新搜索配方，但忽略物品nbt变化。
Lasers do not correctly update their recipe cache. They only re-search for recipes when the item itself changes, but ignore changes to the item's NBT.

其中一个比较明显的影响是，序列组装中的激光切割步骤会执行错误的步骤，玩家可以用该bug跳过激光加工前的步骤，也会被这个bug吞掉激光加工之后的步骤。
One noticeable consequence is that the laser cutting step in Sequenced Assembly may execute the wrong step.
Players can use this bug to skip steps that are supposed to occur before the laser processing stage, and steps that should occur after the laser stage may also be unintentionally consumed by this bug.