### PR TITLE
Improve Helve performance and fix bugs

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlock.java
@@ -135,6 +135,14 @@ public class HelveBlock extends HorizontalDirectionalBlock implements IBE<HelveB
 		pLevel.removeBlockEntity(pPos);
 	}
 
+    @Override
+    public void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos fromPos, boolean isMoving) {
+        super.neighborChanged(state, level, pos, block, fromPos, isMoving);
+        if (fromPos.equals(pos.below())) {
+            withBlockEntityDo(level, pos, HelveBlockEntity::updateAnvilState);
+        }
+    }
+
 	@Override
 	public void tick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
 

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlockEntity.java
@@ -66,7 +66,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	private SmithingRecipe lastSmithingRecipe;
 	private HammeringRecipe lastHammeringRecipe;
 	boolean lastRecipeIsAssembly;
-	private boolean contentsChanged;
+	private boolean recipesDirty;
 	private static final Object hammeringRecipesKey = new Object();
 	private int operatingMode;
 	Block anvilBlock;
@@ -82,15 +82,15 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	public HelveBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
 
-		inputInv = new SmartInventory(3, this).whenContentsChanged(slot -> contentsChanged = true);
+		inputInv = new SmartInventory(3, this).whenContentsChanged(slot -> recipesDirty = true);
 		bufInv = new SmartInventory(3, this);
-		outputInv = new SmartInventory(3, this).whenContentsChanged(slot -> contentsChanged = true);
+		outputInv = new SmartInventory(3, this).whenContentsChanged(slot -> recipesDirty = true);
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
 		operatingMode = 0;
 		hammerBlows = 0;
 		anvilBlock = Blocks.AIR;
 		blockedSlots = 0;
-		contentsChanged = true;
+		recipesDirty = true;
 	}
 
 	public void resetRecipes() {
@@ -115,6 +115,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		compound.put("OutputInventory", outputInv.serializeNBT());
 		compound.putBoolean("LastRecipeIsAssembly", lastRecipeIsAssembly);
 		compound.putInt("BlockedSlots", blockedSlots);
+		compound.putInt("OperatingMode", operatingMode);
 		super.write(compound, clientPacket);
 	}
 
@@ -127,15 +128,16 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		outputInv.deserializeNBT(compound.getCompound("OutputInventory"));
 		lastRecipeIsAssembly = compound.getBoolean("LastRecipeIsAssembly");
 		blockedSlots = compound.getInt("BlockedSlots");
+		operatingMode = compound.getInt("OperatingMode");
 	}
 
 	public boolean addBlockedSlots() {
 		if (blockedSlots >= 2) return false;
 		blockedSlots += 1;
 		ItemHelper.dropContents(level, worldPosition, inputInv);
-		inputInv = new SmartInventory(3 - blockedSlots, this).whenContentsChanged(slot -> contentsChanged = true);
+		inputInv = new SmartInventory(3 - blockedSlots, this).whenContentsChanged(slot -> recipesDirty = true);
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
-		contentsChanged = true;
+		recipesDirty = true;
 		resetRecipes();
 		return true;
 	}
@@ -150,9 +152,9 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		ItemStack itemStack = new ItemStack(VintageItems.HELVE_HAMMER_SLOT_COVER.get(), blockedSlots);
 		blockedSlots = 0;
 		ItemHelper.dropContents(level, worldPosition, inputInv);
-		inputInv = new SmartInventory(3, this).whenContentsChanged(slot -> contentsChanged = true);
+		inputInv = new SmartInventory(3, this).whenContentsChanged(slot -> recipesDirty = true);
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
-		contentsChanged = true;
+		recipesDirty = true;
 		resetRecipes();
 		return itemStack;
 	}
@@ -178,17 +180,19 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 			inputInv.clearContent();
 			outputInv.clearContent();
 		}
+
+		if (!level.isClientSide) {
+			sendData();
+		}
 	}
 
 	public float getHammerAngle() {
 		if (timer <= 0) return 0.0f;
 
-		if (operatingMode > 0) {
-			if ((operatingMode == 2 && lastSmithingRecipe != null) || (operatingMode == 1 && lastHammeringRecipe != null)) {
-				if (timer > 25)
-					return -25f + (timer / 20f);
-				return timer * -1f;
-			}
+		if (operatingMode == 1 && hammerBlows > 0 || operatingMode == 2) {
+			if (timer > 25)
+				return -25f + (timer / 20f);
+			return timer * -1f;
 		}
 
 		return 0.0f;
@@ -217,7 +221,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	public void updateAnvilState() {
 		if (level == null) return;
 		needsAnvilUpdate = false;
-		contentsChanged = true;
+		recipesDirty = true;
 
 		Block blockBelow = level.getBlockState(worldPosition.below()).getBlock();
 		if (blockBelow instanceof AnvilBlock ||
@@ -243,13 +247,12 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	public void tick() {
 		super.tick();
 
-		if (needsAnvilUpdate) {
-			updateAnvilState();
-		}
-
 		if (level.isClientSide) {
 			tickClient();
 		} else {
+			if (needsAnvilUpdate) {
+				updateAnvilState();
+			}
 			tickServer();
 		}
 	}
@@ -258,16 +261,27 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		float speed = getSpeed();
 		int processingSpeed = getProcessingSpeed(speed);
 
-		if (operatingMode == 1 && timer > 0 && lastHammeringRecipe != null) {
+		if (speed == 0) {
+			timer = 0;
+			return;
+		}
+
+		if (operatingMode == 1 && timer > 0 && hammerBlows > 0) {
 			timer -= processingSpeed;
 			if (timer > 0 && timer - processingSpeed <= 0) {
 				spawnEventParticles(inputInv.getStackInSlot(0));
 				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playAt(level, worldPosition, 3, 1, true);
 			}
+			if (timer <= 0) {
+				timer = 500;
+			}
 		}
-		else if (operatingMode == 2 && timer > 0 && timer - processingSpeed * 2 <= 0) {
-			spawnEventParticles(inputInv.getStackInSlot(0));
-			AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playAt(level, worldPosition, 3, 1, true);
+		else if (operatingMode == 2 && timer > 0) {
+			timer -= processingSpeed;
+			if (timer > 0 && timer - processingSpeed * 2 <= 0) {
+				spawnEventParticles(inputInv.getStackInSlot(0));
+				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playAt(level, worldPosition, 3, 1, true);
+			}
 		}
 	}
 
@@ -276,15 +290,21 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		int processingSpeed = getProcessingSpeed(speed);
 
 		if (operatingMode == 1) {
-			for (int i = 0; i < outputInv.getSlots(); i++)
-				if (outputInv.getStackInSlot(i)
-						.getCount() == outputInv.getSlotLimit(i))
-					return;
+			boolean outputFull = true;
+			for (int i = 0; i < outputInv.getSlots(); i++) {
+				if (outputInv.getStackInSlot(i).getCount() < outputInv.getSlotLimit(i)) {
+					outputFull = false;
+					break;
+				}
+			}
+			if (outputFull) return;
 
 			if (timer > 0) {
 				if (speed == 0) {
 					timer = 0;
 					lastHammeringRecipe = null;
+					recipesDirty = true;
+					sendData();
 				}
 
 				if (lastHammeringRecipe != null) {
@@ -296,7 +316,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 						if (hammerBlows <= 0) {
 							process();
 							lastHammeringRecipe = null;
-							contentsChanged = true;
+							recipesDirty = true;
 							sendData();
 						} else timer = 500;
 					}
@@ -304,11 +324,11 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 				}
 			}
 
-			if (inputInv.isEmpty()) return;
+			if (!recipesDirty) return;
 			if (speed == 0) return;
-			if (!contentsChanged) return;
+			if (inputInv.isEmpty() && outputInv.isEmpty()) return;
 
-			contentsChanged = false;
+			recipesDirty = false;
 
 			if (lastHammeringRecipe == null || !HammeringRecipe.match(this, lastHammeringRecipe)) {
 
@@ -364,8 +384,8 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 			for (int i = 0; i < inputInv.getSlots(); i++)
 				if (!inputInv.getStackInSlot(i).isEmpty()) slots++;
 
-			if (lastSmithingRecipe == null && contentsChanged && slots >= (VintageConfig.server().recipes.allowTemplatelessRecipes.get() ? 2 : 3) && speed != 0) {
-				contentsChanged = false;
+			if (lastSmithingRecipe == null && recipesDirty && slots >= (VintageConfig.server().recipes.allowTemplatelessRecipes.get() ? 2 : 3) && speed != 0) {
+				recipesDirty = false;
 				for (SmithingRecipe recipe : VintageRecipesList.getSmithing()) {
 					boolean template = false;
 					boolean base = false;
@@ -383,6 +403,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 					if (template && base && addition) {
 						lastSmithingRecipe = recipe;
 						timer = 500;
+						sendData();
 						break;
 					}
 				}
@@ -391,6 +412,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 			if (lastSmithingRecipe != null && (slots < (VintageConfig.server().recipes.allowTemplatelessRecipes.get() ? 2 : 3) || speed == 0)) {
 				lastSmithingRecipe = null;
 				timer = 0;
+				sendData();
 			}
 
 			if (timer > 0) {
@@ -400,7 +422,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 					if (timer <= 0) {
 						processSmith();
 						lastSmithingRecipe = null;
-						contentsChanged = true;
+						recipesDirty = true;
 						sendData();
 					}
 					return;
@@ -526,7 +548,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	@Override
 	public void setChanged() {
 		super.setChanged();
-		contentsChanged = true;
+		recipesDirty = true;
 	}
 
 	@Override

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlockEntity.java
@@ -72,6 +72,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	Block anvilBlock;
 	VintageAdvancementBehaviour advancementBehaviour;
 	private int blockedSlots;
+	private boolean needsAnvilUpdate = true;
 
 	public static final TagKey<Item> customAnvilTag =
 			ItemTags.create(new ResourceLocation("vintageimprovements", "custom_hammering_blocks"));
@@ -81,14 +82,15 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	public HelveBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
 
-		inputInv = new SmartInventory(3, this);
+		inputInv = new SmartInventory(3, this).whenContentsChanged(slot -> contentsChanged = true);
 		bufInv = new SmartInventory(3, this);
-		outputInv = new SmartInventory(3, this);
+		outputInv = new SmartInventory(3, this).whenContentsChanged(slot -> contentsChanged = true);
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
 		operatingMode = 0;
 		hammerBlows = 0;
 		anvilBlock = Blocks.AIR;
 		blockedSlots = 0;
+		contentsChanged = true;
 	}
 
 	public void resetRecipes() {
@@ -131,8 +133,9 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		if (blockedSlots >= 2) return false;
 		blockedSlots += 1;
 		ItemHelper.dropContents(level, worldPosition, inputInv);
-		inputInv = new SmartInventory(3 - blockedSlots, this);
+		inputInv = new SmartInventory(3 - blockedSlots, this).whenContentsChanged(slot -> contentsChanged = true);
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
+		contentsChanged = true;
 		resetRecipes();
 		return true;
 	}
@@ -147,8 +150,9 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		ItemStack itemStack = new ItemStack(VintageItems.HELVE_HAMMER_SLOT_COVER.get(), blockedSlots);
 		blockedSlots = 0;
 		ItemHelper.dropContents(level, worldPosition, inputInv);
-		inputInv = new SmartInventory(3, this);
+		inputInv = new SmartInventory(3, this).whenContentsChanged(slot -> contentsChanged = true);
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
+		contentsChanged = true;
 		resetRecipes();
 		return itemStack;
 	}
@@ -210,20 +214,22 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		}
 	}
 
-	@Override
-	public void tick() {
-		super.tick();
+	public void updateAnvilState() {
+		if (level == null) return;
+		needsAnvilUpdate = false;
+		contentsChanged = true;
 
-		if (level.getBlockState(worldPosition.below()).getBlock() instanceof AnvilBlock ||
-				level.getBlockState(worldPosition.below()).getBlock().asItem().getDefaultInstance().is(anvilTag)) {
+		Block blockBelow = level.getBlockState(worldPosition.below()).getBlock();
+		if (blockBelow instanceof AnvilBlock ||
+				blockBelow.asItem().getDefaultInstance().is(anvilTag)) {
 			changeMode(1);
 			anvilBlock = Blocks.AIR;
 		}
-		else if (level.getBlockState(worldPosition.below()).getBlock().asItem().getDefaultInstance().is(customAnvilTag)) {
+		else if (blockBelow.asItem().getDefaultInstance().is(customAnvilTag)) {
 			changeMode(1);
-			anvilBlock = level.getBlockState(worldPosition.below()).getBlock();
+			anvilBlock = blockBelow;
 		}
-		else if (level.getBlockState(worldPosition.below()).is(Blocks.SMITHING_TABLE)) {
+		else if (blockBelow == Blocks.SMITHING_TABLE) {
 			changeMode(2);
 			anvilBlock = Blocks.AIR;
 		}
@@ -231,6 +237,43 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 			changeMode(0);
 			anvilBlock = Blocks.AIR;
 		}
+	}
+
+	@Override
+	public void tick() {
+		super.tick();
+
+		if (needsAnvilUpdate) {
+			updateAnvilState();
+		}
+
+		if (level.isClientSide) {
+			tickClient();
+		} else {
+			tickServer();
+		}
+	}
+
+	private void tickClient() {
+		float speed = getSpeed();
+		int processingSpeed = getProcessingSpeed(speed);
+
+		if (operatingMode == 1 && timer > 0 && lastHammeringRecipe != null) {
+			timer -= processingSpeed;
+			if (timer > 0 && timer - processingSpeed <= 0) {
+				spawnEventParticles(inputInv.getStackInSlot(0));
+				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playAt(level, worldPosition, 3, 1, true);
+			}
+		}
+		else if (operatingMode == 2 && timer > 0 && timer - processingSpeed * 2 <= 0) {
+			spawnEventParticles(inputInv.getStackInSlot(0));
+			AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playAt(level, worldPosition, 3, 1, true);
+		}
+	}
+
+	private void tickServer() {
+		float speed = getSpeed();
+		int processingSpeed = getProcessingSpeed(speed);
 
 		if (operatingMode == 1) {
 			for (int i = 0; i < outputInv.getSlots(); i++)
@@ -239,25 +282,21 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 					return;
 
 			if (timer > 0) {
-				if (getSpeed() == 0) {
+				if (speed == 0) {
 					timer = 0;
 					lastHammeringRecipe = null;
 				}
 
 				if (lastHammeringRecipe != null) {
-					timer -= getProcessingSpeed();
+					timer -= processingSpeed;
 
-					if (level.isClientSide && timer > 0 && timer - getProcessingSpeed() <= 0) {
-						spawnEventParticles(inputInv.getStackInSlot(0));
-						AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playAt(level, worldPosition, 3, 1, true);
-						return;
-					}
 					if (timer <= 0) {
 						hammerBlows--;
 
 						if (hammerBlows <= 0) {
 							process();
 							lastHammeringRecipe = null;
+							contentsChanged = true;
 							sendData();
 						} else timer = 500;
 					}
@@ -266,6 +305,10 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 			}
 
 			if (inputInv.isEmpty()) return;
+			if (speed == 0) return;
+			if (!contentsChanged) return;
+
+			contentsChanged = false;
 
 			if (lastHammeringRecipe == null || !HammeringRecipe.match(this, lastHammeringRecipe)) {
 
@@ -303,8 +346,9 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 
 				lastRecipeIsAssembly = false;
 
-				if (!getRecipes().isEmpty()) {
-					if (getRecipes().get(0) instanceof HammeringRecipe hammering) {
+				List<Recipe<?>> recipes = getRecipes();
+				if (!recipes.isEmpty()) {
+					if (recipes.get(0) instanceof HammeringRecipe hammering) {
 						lastHammeringRecipe = hammering;
 						timer = 500;
 						hammerBlows = hammering.hammerBlows;
@@ -316,16 +360,12 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 
 		}
 		else if (operatingMode == 2) {
-			if (level.isClientSide && timer > 0 && timer - getProcessingSpeed() * 2 <= 0) {
-				spawnEventParticles(inputInv.getStackInSlot(0));
-				AllSoundEvents.MECHANICAL_PRESS_ACTIVATION.playAt(level, worldPosition, 3, 1, true);
-			}
-
 			int slots = 0;
 			for (int i = 0; i < inputInv.getSlots(); i++)
 				if (!inputInv.getStackInSlot(i).isEmpty()) slots++;
 
-			if (lastSmithingRecipe == null && slots >= (VintageConfig.server().recipes.allowTemplatelessRecipes.get() ? 2 : 3) && getSpeed() != 0) {
+			if (lastSmithingRecipe == null && contentsChanged && slots >= (VintageConfig.server().recipes.allowTemplatelessRecipes.get() ? 2 : 3) && speed != 0) {
+				contentsChanged = false;
 				for (SmithingRecipe recipe : VintageRecipesList.getSmithing()) {
 					boolean template = false;
 					boolean base = false;
@@ -348,20 +388,19 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 				}
 			}
 
-			if (lastSmithingRecipe != null && (slots < (VintageConfig.server().recipes.allowTemplatelessRecipes.get() ? 2 : 3) || getSpeed() == 0)) {
+			if (lastSmithingRecipe != null && (slots < (VintageConfig.server().recipes.allowTemplatelessRecipes.get() ? 2 : 3) || speed == 0)) {
 				lastSmithingRecipe = null;
 				timer = 0;
 			}
 
 			if (timer > 0) {
 				if (lastSmithingRecipe != null) {
-					timer -= getProcessingSpeed();
-
-					if (level.isClientSide) return;
+					timer -= processingSpeed;
 
 					if (timer <= 0) {
 						processSmith();
 						lastSmithingRecipe = null;
+						contentsChanged = true;
 						sendData();
 					}
 					return;
@@ -485,6 +524,12 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 	}
 
 	@Override
+	public void setChanged() {
+		super.setChanged();
+		contentsChanged = true;
+	}
+
+	@Override
 	public void invalidate() {
 		super.invalidate();
 		capability.invalidate();
@@ -583,8 +628,8 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		return 0;
 	}
 
-	public int getProcessingSpeed() {
-		return Mth.clamp((int) Math.abs(getSpeed() / 16f), 1, 512);
+	public int getProcessingSpeed(float speed) {
+		return Mth.clamp((int) Math.abs(speed / 16f), 1, 512);
 	}
 
 	private class HelveInventoryHandler extends CombinedInvWrapper {

--- a/src/main/java/com/negodya1/vintageimprovements/infrastructure/ponder/scenes/HelveScenes.java
+++ b/src/main/java/com/negodya1/vintageimprovements/infrastructure/ponder/scenes/HelveScenes.java
@@ -185,7 +185,7 @@ public class HelveScenes {
 		Vec3 helveTop = util.vector().centerOf(helve);
 		scene.overlay().showText(40)
 				.attachKeyFrame()
-				.text("Some recipes may require less then 3 ingredients")
+				.text("Some recipes may require less than 3 ingredients")
 				.pointAt(helveTop)
 				.placeNearTarget();
 		scene.idle(50);

--- a/src/main/resources/assets/vintageimprovements/lang/en_us.json
+++ b/src/main/resources/assets/vintageimprovements/lang/en_us.json
@@ -393,7 +393,7 @@
 	"vintageimprovements.ponder.helve_hammer.text_9": "Items can also be extracted/inserted by automation",
 	
 	"vintageimprovements.ponder.slots_blocking.header": "Helve Hammer slots blocking",
-	"vintageimprovements.ponder.slots_blocking.text_1": "Some recipes may require less then 3 ingredients",
+	"vintageimprovements.ponder.slots_blocking.text_1": "Some recipes may require less than 3 ingredients",
 	"vintageimprovements.ponder.slots_blocking.text_2": "You can block redundant slots with Helve Hammer Slot Cover",
 	"vintageimprovements.ponder.slots_blocking.text_3": "You can remove Slot Covers via right-click with a Wrench",
 	


### PR DESCRIPTION
Before:
<img width="1479" height="687" alt="Screenshot 2026-03-15 114020" src="https://github.com/user-attachments/assets/8235cb2d-c7ae-466c-ac0b-580138e312aa" />

After:
<img width="1009" height="522" alt="Screenshot 2026-03-15 121734" src="https://github.com/user-attachments/assets/9165fd25-ef59-4e56-9af5-c0defb8e1d14" />

# Current state:
### Performance
When a helve hammer has blocked outputs, it will recalculate all recipes several times per tick in various getRecipe and getRecipes calls. This makes it very slow; the above is on a cpu with good single threading and caching, but I've seen >300µs/t for a helve hammer on worse CPUs

The lower 20µs per tick for the green ones is likely due to hardware L1/L2 caching, so this may be worse in a crowded server with many block entities where the helves aren't guaranteed to be processed in sequence.

Additionally, the client and the server both do this lengthy process, even though the client doesn't really have a reason to. This masked a bunch of places where data wasn't properly synced because the client would just calculate everything for itself anyway.

### Bugs

\- When one of the 3 output slots is full, the helve hammer will stop, even if the other 2 output slots are empty.
\- When going through a two-step hammering, the helve takes items from its own output. However, if the input is empty, it exits early. This always leaves one last unprocessed ingot in the output

# PR changes:
### Performance
\- Caching of recipes, and only recalculating recipes when necessary such as when inventory changes (via whenContentsChanged), recipe finishes, anvil below changes (via neighborChanged), or speed input gets removed during a recipe.\
\- Separation of responsibilities for client and server with syncing when necessary.\
\- Caching of repeated calls to getSpeed and level.getBlockState(worldPosition.below()).getBlock()\
\- Don't check any recipes when speed is zero.

### Bugfixes

\- Check if any output slots are empty.
\- Check if both input and output slots are empty before exiting early.

### Typo fix

`less then 3` -> `less than 3`