### PR TITLE
Fix processingTicks in vacuum chamber

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
@@ -187,10 +187,10 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 					if (currentRecipe instanceof ProcessingRecipe) {
 						int t = ((ProcessingRecipe<?>) currentRecipe).getProcessingDuration();
 						if (t != 0)
-							recipeSpeed = t / 100f;
+							recipeSpeed = (0.15f * t * (3000 / (t + 3000))) / 15f;
 					}
 
-					processingTicks = Mth.clamp((Mth.log2((int) (512 / speed))) * Mth.ceil(recipeSpeed * 15) + 1, 1, 512);
+					processingTicks = Mth.clamp((Mth.log2(512 / speed)) * Mth.ceil(recipeSpeed * 15) + 1, 1, 512);
 
 					Optional<BasinBlockEntity> basin = getBasin();
 					if (basin.isPresent()) {


### PR DESCRIPTION
processingTicks is constant at 512 when processingDuration is more than roughly 3000. It was replaced with a fairly arbitrary formula that tries to keep close to the original formula while working for large processingDuration values.



https://github.com/user-attachments/assets/856f78b5-fefe-4ab9-9f2b-17271d2ca9a7


pictured is the graph with t being processingDuration, x axis being rpm and y axis being processingTicks
red is the original formula, blue is the new formula
base create allows up to 256 RPM.

Maybe you could consider making the processingDuration be inversely proportional to RPM but that is a balancing change I do not wish to impose upon you.