### PR TITLE
Fix issue where schematic printing of a vacuum chamber ignores the mode setting

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
@@ -161,6 +161,11 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 	}
 
 	@Override
+	public void writeSafe(CompoundTag compound) {
+		compound.putBoolean("Mode", mode);
+	}
+
+	@Override
 	public void tick() {
 		super.tick();
 

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
@@ -162,6 +162,7 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 
 	@Override
 	public void writeSafe(CompoundTag compound) {
+		super.writeSafe(compound);
 		compound.putBoolean("Mode", mode);
 	}
 


### PR DESCRIPTION
实现了PartialSafeNBT接口，现在Mode属性会正确打印了
Implemented PartialSafeNBT, marking Mode as safe nbt