### PR TITLE
Sync BE updates to bystanders

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/centrifuge/CentrifugeBlockEntity.java
@@ -107,6 +107,7 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 		if (basins >= 4) return false;
 		if (items.getItem() != AllBlocks.BASIN.asItem()) return false;
 		basins += 1;
+        notifyUpdate();
 		return true;
 	}
 
@@ -118,6 +119,7 @@ public class CentrifugeBlockEntity extends KineticBlockEntity implements IHaveGo
 		if (redstoneApp) return false;
 		if (items.getItem() != VintageItems.REDSTONE_MODULE.get()) return false;
 		redstoneApp = true;
+        notifyUpdate();
 		return true;
 	}
 

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/curving_press/CurvingPressBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/curving_press/CurvingPressBlockEntity.java
@@ -82,6 +82,7 @@ public class CurvingPressBlockEntity extends KineticBlockEntity implements Curvi
 		if (redstoneModule) return false;
 		if (items.getItem() != VintageItems.REDSTONE_MODULE.get()) return false;
 		redstoneModule = true;
+        notifyUpdate();
 		return true;
 	}
 

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/grinder/GrinderBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/grinder/GrinderBlockEntity.java
@@ -548,27 +548,30 @@ public class GrinderBlockEntity extends KineticBlockEntity implements IHaveGoggl
 		switch (items.getItem().getDescriptionId()) {
 			case "item.create.sand_paper":
 				textureType = 0;
-				return true;
+                break;
 
 			case "item.create.red_sand_paper":
 				textureType = 1;
-				return true;
+                break;
 
 			case "item.createaddition.diamond_grit_sandpaper", "item.create_so.diamond_sandpaper":
 				textureType = 2;
-				return true;
+                break;
 
 			case "item.create_so.iron_sandpaper":
 				textureType = 3;
-				return true;
+                break;
 
 			case "item.create_so.obsidian_sandpaper":
 				textureType = 4;
-				return true;
+                break;
 
 			default:
 				return false;
 		}
+
+        notifyUpdate();
+        return true;
 	}
 
 }

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HelveBlockEntity.java
@@ -139,6 +139,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
 		recipesDirty = true;
 		resetRecipes();
+        notifyUpdate();
 		return true;
 	}
 
@@ -156,6 +157,7 @@ public class HelveBlockEntity extends SmartBlockEntity implements IHaveGoggleInf
 		capability = LazyOptional.of(() -> new HelveInventoryHandler(inputInv, outputInv));
 		recipesDirty = true;
 		resetRecipes();
+        notifyUpdate();
 		return itemStack;
 	}
 

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlockEntity.java
@@ -83,6 +83,7 @@ public class VacuumChamberBlockEntity extends BasinOperatingBlockEntity {
 	public boolean changeMode() {
 		basinChecker.scheduleUpdate();
 		mode = !mode;
+        notifyUpdate();
 		return mode;
 	}
 


### PR DESCRIPTION
Fixes Vintage Improvement's part of https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/1855

### Bug details:
When placing the 4 basins on the centrifuge, only the player placing them sees the basins as being present. Any bystanders still see the centrifuge without basins. Spinning it populates it.

The cause is that the data isn't synced when placing a basin.

### Fix details:
I went through all the block entities and checked if any methods modify data that gets saved in write(). If so, I checked if these methods call for an update.

I found several places where that was not the case, and added a notifyUpdate to them.

I don't know if I got them all, but it's not a game-breaking bug nor would this PR break anything if it's redundant in any place.