### PR TITLE
Fix vacuum chamber not syncing with other clients on mode change

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/vacuum_chamber/VacuumChamberBlock.java
@@ -103,6 +103,7 @@ public class VacuumChamberBlock extends KineticBlock implements IBE<VacuumChambe
 		if (be != null && be.runningTicks == 0)
 		{
 			be.changeMode();
+			be.sendData();
 			if (worldIn.isClientSide()) {
 				AllSoundEvents.WRENCH_ROTATE.playAt(worldIn, pos, 3, 1, true);
 			}


### PR DESCRIPTION
扳手右键更改压缩机模式时，服务端不会向其他客户端同步变化。单人时也可以用机械手扳压缩机来观察到这个现象。
Changing the vacuum chamber mode does not sync the change to other clients. In singleplayer, this can be observed by using a deployer to change mode.