### PR TITLE
Add KubeJS recipe support for Vintage Improvements recipe types

### DIFF
--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/curving_press/CurvingRecipe.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/curving_press/CurvingRecipe.java
@@ -86,6 +86,11 @@ public class CurvingRecipe extends ProcessingRecipe<RecipeWrapper, CurvingRecipe
 	}
 	
 	@Override
+	protected boolean canSpecifyDuration() {
+		return true;
+	}
+
+	@Override
 	public void addRequiredMachines(Set<ItemLike> list) {
 		list.add(VintageBlocks.CURVING_PRESS.get());
 	}

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HammeringRecipe.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/helve_hammer/HammeringRecipe.java
@@ -149,6 +149,11 @@ public class HammeringRecipe extends ProcessingRecipe<RecipeInput, HammeringReci
 	}
 
 	@Override
+	protected boolean canSpecifyDuration() {
+		return true;
+	}
+
+	@Override
 	public void addRequiredMachines(Set<ItemLike> list) {
 		list.add(VintageBlocks.HELVE.get());
 	}

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/laser/LaserCuttingRecipe.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/laser/LaserCuttingRecipe.java
@@ -71,6 +71,11 @@ public class LaserCuttingRecipe extends ProcessingRecipe<RecipeWrapper, LaserCut
 	}
 	
 	@Override
+	protected boolean canSpecifyDuration() {
+		return true;
+	}
+
+	@Override
 	public void addRequiredMachines(Set<ItemLike> list) {
 		list.add(VintageBlocks.LASER.get());
 	}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/centrifugation.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/centrifugation.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_unwrapped"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/coiling.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/coiling.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_unwrapped"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/curving.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/curving.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_with_time"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/hammering.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/hammering.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_unwrapped"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/laser_cutting.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/laser_cutting.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_unwrapped"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/polishing.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/polishing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_with_time"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/pressurizing.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/pressurizing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_with_time"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/turning.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/turning.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_with_time"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/vacuumizing.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/vacuumizing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_with_time"
+}

--- a/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/vibrating.json
+++ b/src/main/resources/data/vintageimprovements/kubejs/recipe_schema/vibrating.json
@@ -1,0 +1,3 @@
+{
+  "parent": "create:base/processing_with_time"
+}


### PR DESCRIPTION
- Override `canSpecifyDuration()` to return `true` in `CurvingRecipe`, `HammeringRecipe`, and `LaserCuttingRecipe`, matching the other recipe types that already support it
- Add KubeJS recipe schema JSON files for all 10 recipe types (curving, hammering, polishing, turning, vibrating, coiling, centrifugation, laser cutting, pressurizing, vacuumizing), enabling the `event.recipes.vintageimprovements.*` builder pattern in KubeJS scripts
