### PR TITLE
修复车床旋转导致的崩溃

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Create: Vintage Improvements
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=1.20.1-0.3.7.3
+mod_version=1.20.1-0.3.7.4
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingBlock.java
@@ -157,7 +157,8 @@ public class LatheMovingBlock extends DirectionalKineticBlock implements IWrench
 
 		if (!directlyAdjacent && stillValid(level, targetedPos, targetedState, true))
 			return true;
-		return targetedState.getBlock() instanceof LatheRotatingBlock;
+		return targetedState.getBlock() instanceof LatheRotatingBlock
+				&& targetedState.getValue(LatheRotatingBlock.HORIZONTAL_FACING) == direction;
 	}
 
 	@Override

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingBlock.java
@@ -54,12 +54,16 @@ public class LatheMovingBlock extends DirectionalKineticBlock implements IWrench
 
 	@Override
 	public Direction.Axis getRotationAxis(BlockState state) {
-		return state.getValue(FACING).getClockWise().getAxis();
+		Direction facing = state.getValue(FACING);
+		if (!isHorizontal(facing))
+			return Direction.Axis.X;
+		return facing.getClockWise().getAxis();
 	}
 
 	@Override
 	public boolean hasShaftTowards(LevelReader world, BlockPos pos, BlockState state, Direction face) {
-		return face.getAxis() == state.getValue(FACING).getClockWise().getAxis();
+		Direction facing = state.getValue(FACING);
+		return isHorizontal(facing) && face.getAxis() == facing.getClockWise().getAxis();
 	}
 
 	@Override
@@ -80,6 +84,24 @@ public class LatheMovingBlock extends DirectionalKineticBlock implements IWrench
 	@Override
 	public InteractionResult onWrenched(BlockState state, UseOnContext context) {
 		return InteractionResult.PASS;
+	}
+
+	@Override
+	public BlockState getRotatedBlockState(BlockState state, Direction targetedFace) {
+		Direction facing = state.getValue(FACING);
+		if (!isHorizontal(facing) || facing.getAxis() == targetedFace.getAxis())
+			return state;
+		Direction rotated = facing.getClockWise(targetedFace.getAxis());
+		return isHorizontal(rotated) ? state.setValue(FACING, rotated) : state;
+	}
+
+	@Override
+	public BlockState rotate(BlockState state, Rotation rotation) {
+		Direction facing = state.getValue(FACING);
+		if (!isHorizontal(facing))
+			return state;
+		Direction rotated = rotation.rotate(facing);
+		return isHorizontal(rotated) ? state.setValue(FACING, rotated) : state;
 	}
 
 	@Override
@@ -152,6 +174,8 @@ public class LatheMovingBlock extends DirectionalKineticBlock implements IWrench
 			return false;
 
 		Direction direction = state.getValue(FACING);
+		if (!isHorizontal(direction))
+			return false;
 		BlockPos targetedPos = pos.relative(direction);
 		BlockState targetedState = level.getBlockState(targetedPos);
 
@@ -159,6 +183,10 @@ public class LatheMovingBlock extends DirectionalKineticBlock implements IWrench
 			return true;
 		return targetedState.getBlock() instanceof LatheRotatingBlock
 				&& targetedState.getValue(LatheRotatingBlock.HORIZONTAL_FACING) == direction;
+	}
+
+	private static boolean isHorizontal(Direction direction) {
+		return direction.getAxis() != Direction.Axis.Y;
 	}
 
 	@Override

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
@@ -89,15 +90,16 @@ public class LatheMovingBlockEntity extends KineticBlockEntity implements MenuPr
 	}
 
 	public List<TurningRecipe> getRecipes() {
-		LatheRotatingBlockEntity be = (LatheRotatingBlockEntity) level.getBlockEntity(LatheMovingBlock.getMaster(level, worldPosition, this.getBlockState()));
+		LatheRotatingBlockEntity be = getMasterBlockEntity();
 		if (be == null)
 			return new ArrayList<>();
 		return be.getRecipes();
 	}
 
 	public void resetRecipe() {
-		LatheRotatingBlockEntity be = (LatheRotatingBlockEntity) level.getBlockEntity(LatheMovingBlock.getMaster(level, worldPosition, this.getBlockState()));
-		be.resetRecipe();
+		LatheRotatingBlockEntity be = getMasterBlockEntity();
+		if (be != null)
+			be.resetRecipe();
 	}
 
 	public int getIndex(ItemStack ingredient) {
@@ -123,10 +125,17 @@ public class LatheMovingBlockEntity extends KineticBlockEntity implements MenuPr
 	}
 
 	public SmartInventory getInputInventory() {
-		LatheRotatingBlockEntity be = (LatheRotatingBlockEntity) level.getBlockEntity(LatheMovingBlock.getMaster(level, worldPosition, this.getBlockState()));
+		LatheRotatingBlockEntity be = getMasterBlockEntity();
 		if (be == null)
 			return new SmartInventory(1, this);
 		return be.inputInv;
+	}
+
+	private LatheRotatingBlockEntity getMasterBlockEntity() {
+		BlockEntity blockEntity = level.getBlockEntity(LatheMovingBlock.getMaster(level, worldPosition, this.getBlockState()));
+		if (blockEntity instanceof LatheRotatingBlockEntity lathe)
+			return lathe;
+		return null;
 	}
 
 	public Optional<TurningRecipe> getTemporaryRecipe() {

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingRenderer.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheMovingRenderer.java
@@ -66,6 +66,9 @@ public class LatheMovingRenderer extends KineticBlockEntityRenderer<LatheMovingB
 
 	@Override
 	protected void renderSafe(LatheMovingBlockEntity be, float partialTicks, PoseStack ms, MultiBufferSource buffer, int light, int overlay) {
+		if (be.getBlockState().getValue(FACING).getAxis() == Direction.Axis.Y)
+			return;
+
 		renderSlot(be, ms, buffer, light, overlay);
 
 

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheRotatingBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheRotatingBlock.java
@@ -8,7 +8,9 @@ import com.negodya1.vintageimprovements.content.kinetics.helve_hammer.HelveKinet
 import com.negodya1.vintageimprovements.content.kinetics.helve_hammer.HelveStructuralBlock;
 import com.negodya1.vintageimprovements.foundation.advancement.VintageAdvancementBehaviour;
 import com.simibubi.create.AllShapes;
+import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.content.kinetics.base.HorizontalKineticBlock;
+import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 import com.simibubi.create.foundation.block.IBE;
 
 import net.minecraft.ChatFormatting;
@@ -27,6 +29,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
@@ -92,6 +95,28 @@ public class LatheRotatingBlock extends HorizontalKineticBlock implements IBE<La
 	@Override
 	public SpeedLevel getMinimumRequiredSpeedLevel() {
 		return SpeedLevel.FAST;
+	}
+
+	@Override
+	public InteractionResult onWrenched(BlockState state, UseOnContext context) {
+		Level level = context.getLevel();
+		BlockPos pos = context.getClickedPos();
+		BlockState rotated = getRotatedBlockState(state, context.getClickedFace());
+		BlockPos oldSlavePos = getSlave(level, pos, state);
+		BlockPos newSlavePos = getSlave(level, pos, rotated);
+
+		if (!oldSlavePos.equals(newSlavePos) && !level.getBlockState(newSlavePos).canBeReplaced())
+			return InteractionResult.PASS;
+		if (!rotated.canSurvive(level, pos))
+			return InteractionResult.PASS;
+
+		KineticBlockEntity.switchToBlockState(level, pos, updateAfterWrenched(rotated, context));
+		if (level.getBlockState(pos) != state)
+			IWrenchable.playRotateSound(level, pos);
+
+		if (!level.isClientSide && !level.getBlockTicks().hasScheduledTick(pos, this))
+			level.scheduleTick(pos, this, 1);
+		return InteractionResult.SUCCESS;
 	}
 
 	@Override

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheRotatingBlock.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheRotatingBlock.java
@@ -208,7 +208,7 @@ public class LatheRotatingBlock extends HorizontalKineticBlock implements IBE<La
 				.setValue(HelveStructuralBlock.FACING, side);
 		if (occupiedState != requiredStructure) {
 			if (!occupiedState.canBeReplaced()) {
-				pLevel.destroyBlock(pPos, false);
+				pLevel.destroyBlock(pPos, true);
 				return;
 			}
 			pLevel.setBlockAndUpdate(structurePos, requiredStructure);

--- a/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheRotatingBlockEntity.java
+++ b/src/main/java/com/negodya1/vintageimprovements/content/kinetics/lathe/LatheRotatingBlockEntity.java
@@ -29,6 +29,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
@@ -115,7 +116,7 @@ public class LatheRotatingBlockEntity extends KineticBlockEntity implements IHav
 		List<TurningRecipe> recipes = getRecipes();
 		if (recipes.isEmpty()) return Optional.empty();
 
-		LatheMovingBlockEntity be = (LatheMovingBlockEntity) level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		LatheMovingBlockEntity be = getSlaveBlockEntity();
 		if (be == null)
 			return Optional.empty();
 		if (be.manualMode()) {
@@ -136,7 +137,7 @@ public class LatheRotatingBlockEntity extends KineticBlockEntity implements IHav
 	}
 
 	private ItemStack getResultItem() {
-		LatheMovingBlockEntity be = (LatheMovingBlockEntity) level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		LatheMovingBlockEntity be = getSlaveBlockEntity();
 		if (be == null)
 			return ItemStack.EMPTY;
 		if (!be.recipeSlot.getStackInSlot(0).isEmpty())
@@ -259,9 +260,9 @@ public class LatheRotatingBlockEntity extends KineticBlockEntity implements IHav
 		super.destroy();
 		ItemHelper.dropContents(level, worldPosition, inputInv);
 		ItemHelper.dropContents(level, worldPosition, outputInv);
-		LatheMovingBlockEntity be = (LatheMovingBlockEntity) level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		LatheMovingBlockEntity be = getSlaveBlockEntity();
 		if (be != null)
-			ItemHelper.dropContents(level, LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()), be.recipeSlot);
+			ItemHelper.dropContents(level, be.getBlockPos(), be.recipeSlot);
 	}
 
 	@Override
@@ -320,22 +321,29 @@ public class LatheRotatingBlockEntity extends KineticBlockEntity implements IHav
 				+ Mth.clamp((int) ((Math.abs(getSlaveSpeed()) - IRotate.SpeedLevel.MEDIUM.getSpeedValue()) / (256 - IRotate.SpeedLevel.MEDIUM.getSpeedValue())) / 2f, .0f, 0.5f);
 	}
 
+	private LatheMovingBlockEntity getSlaveBlockEntity() {
+		BlockEntity blockEntity = level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		if (blockEntity instanceof LatheMovingBlockEntity lathe)
+			return lathe;
+		return null;
+	}
+
 	public float getSlaveSpeed() {
-		LatheMovingBlockEntity be = (LatheMovingBlockEntity) level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		LatheMovingBlockEntity be = getSlaveBlockEntity();
 		if (be != null)
 			return be.getSpeed();
 		return 0;
 	}
 
 	public boolean isSlaveSpeedRequirementFulfilled() {
-		LatheMovingBlockEntity be = (LatheMovingBlockEntity) level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		LatheMovingBlockEntity be = getSlaveBlockEntity();
 		if (be != null)
 			return be.isSpeedRequirementFulfilled();
 		return true;
 	}
 
 	public float calculateSlaveStressApplied() {
-		LatheMovingBlockEntity be = (LatheMovingBlockEntity) level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		LatheMovingBlockEntity be = getSlaveBlockEntity();
 		if (be != null)
 			return be.calculateStressApplied();
 		return 0;
@@ -423,7 +431,7 @@ public class LatheRotatingBlockEntity extends KineticBlockEntity implements IHav
 
 		addStressImpactStats(tooltip, stressAtBase);
 
-		LatheMovingBlockEntity be = (LatheMovingBlockEntity) level.getBlockEntity(LatheRotatingBlock.getSlave(level, worldPosition, this.getBlockState()));
+		LatheMovingBlockEntity be = getSlaveBlockEntity();
 		if (be != null) {
 			if (be.manualMode()) {
 				VintageLang.translate("gui.goggles.current_mode")


### PR DESCRIPTION
## 修复内容
- 修复车床主副方块方向错位后，副方块访问主方块实体时可能发生的类型转换崩溃。
- 阻止 `lathe_moving` 被 Create 旋转快捷键或通用旋转逻辑转成 `UP/DOWN` 非法方向。
- 对已存在或绕过入口产生的非法垂直副方块做自清理和客户端渲染兜底，避免渲染阶段崩溃。
- 当主车床因副方块位置被不可替换方块占用而自拆时，掉落车床物品，避免静默消失。
- 将 mod 版本提升到 `1.20.1-0.3.7.4`。

## 问题原因
- 主车床 `LatheRotatingBlock` 使用 `HorizontalKineticBlock` / `HORIZONTAL_FACING`，状态天然只允许水平朝向。
- 副车床 `LatheMovingBlock` 当前继承 `DirectionalKineticBlock`，使用六向 `FACING`，所以状态层面允许 `UP/DOWN`。
- 正常放置和主车床 tick 生成副方块时只会写入水平朝向，但 Create 的旋转快捷键、通用旋转逻辑或其他非标准入口可能直接旋转副方块状态，绕过这个假设。
- 副车床的动力轴和渲染逻辑调用 `FACING.getClockWise()`，该方法只适用于水平朝向；当 `FACING=UP/DOWN` 时会抛出 `IllegalStateException`。

## 改动说明
- `LatheRotatingBlock.onWrenched()`：旋转主车床前检查旋转后的副方块位置。如果新副方块位置不是原位置且不可替换，则拒绝这次旋转，避免主副结构错位并覆盖其他方块实体。
- `LatheMovingBlock.stillValid()`：副方块有效性现在要求主车床朝向与副方块方向匹配，并拒绝 `UP/DOWN`。这样错位或非法副方块会被视为无效结构，后续 tick 会清理。
- `LatheMovingBlockEntity.getMasterBlockEntity()` 和 `LatheRotatingBlockEntity.getSlaveBlockEntity()`：把直接强转改为 `instanceof` 检查。即使结构已经错位，也不会把其他方块实体强转成车床方块实体。
- `LatheMovingBlock.getRotatedBlockState()`：覆盖 Create `IWrenchable` 使用的旋转入口。Create 旋转快捷键可能绕水平轴旋转六向 `FACING`，因此这里在旋转结果不是水平朝向时返回原状态，防止生成 `lathe_moving[facing=up/down]`。
- `LatheMovingBlock.rotate()`：覆盖 Minecraft/其他系统常用的通用 `BlockState#rotate` 入口。结构、蓝图、其他 mod 或机械结构回放可能走这个路径，所以这里也只允许水平旋转结果。
- `LatheMovingBlock.getRotationAxis()` / `hasShaftTowards()`：对已经存在的非法垂直状态做防御。非法状态不再调用 `getClockWise()` 崩溃；动力连接查询会返回不可连接。
- `LatheMovingRenderer.renderSafe()`：客户端如果短暂收到非法垂直副方块状态，直接跳过渲染，避免服务端清理前客户端先崩溃。
- `LatheRotatingBlock.tick()`：当副方块目标位置被不可替换方块占用时，车床仍会自拆，但现在会掉落物品，避免静默消失。

## 兼容性说明
- 这个 PR 保留 `lathe_moving` 现有六向 `FACING` 状态定义，以降低旧存档、blockstate 和模型兼容风险。
- 如果后续希望从类型层面彻底避免非法状态，可以考虑把 `lathe_moving` 改为水平属性或水平基类；这会改变方块状态定义，可能需要额外处理旧存档兼容。

## 验证
- 本地 `gradle build` 通过。
- 在整合包环境中测试：扳手旋转和 Create 旋转快捷键不再复现崩溃。
- 测试 Create 旋转快捷键把车床旋向抽屉等不可替换方块时，车床会掉落而不是静默消失。